### PR TITLE
Using odoo 10.0 RegistryManager.get behavior change

### DIFF
--- a/anybox/recipe/odoo/runtime/session.py
+++ b/anybox/recipe/odoo/runtime/session.py
@@ -465,7 +465,7 @@ class Session(object):
         config['without_demo'] = not getattr(self, 'with_demo', open_with_demo)
         for module in modules:
             config['init'][module] = 1
-        self._registry = odoo.modules.registry.RegistryManager.get(
+        self._registry = odoo.modules.registry.RegistryManager.new(
             db, update_module=True, force_demo=self.with_demo)
         config['init'].clear()
         config['without_demo'] = saved_without_demo


### PR DESCRIPTION
it do not sent properties likes force_demo/status/update_modules so instanciate
a we needs to instaniate new registry while installing module.

In any odoo version we were already getting a new registry as install step
occured while loading the registry.